### PR TITLE
add dependency resolution to function invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
-.tox
+.hypothesis
 nosetests.xml
+.tox
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
 sudo: false
 install:
   - "pip install -qU --compile pip"
-  - "pip install -qU --compile coverage flake8 sphinx_rtd_theme"
+  - "pip install -qU --compile coverage flake8 hypothesis sphinx_rtd_theme"
 script:
   - "pip install -qU --compile ."
   - "SPHINXOPTS='-n -W' make -eC docs html"

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   pre:
     - pip3 install -qU --compile pip
   override:
-    - pip3 install -qU --compile coverage flake8 nose
+    - pip3 install -qU --compile coverage flake8 hypothesis nose
     - pip3 install -qU --compile sphinx_rtd_theme
   post:
     - python setup.py install

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ build-dir = docs/_build
 [flake8]
 count = True
 format = pylint
-exclude = docs/,build/,ez_setup.py
+exclude = docs/,build/,ez_setup.py,.hypothesis/
 ignore = E128,E201,E202,E251,E501
 
 [nosetests]

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ PARAMS['extras_require'] = {}
 PARAMS['test_suite'] = 'nose.collector'
 PARAMS['tests_require'] = [
     'coverage',
+    'hypothesis',
     'nose',
 ]
 

--- a/test_torment/test_unit/test_fixtures/__init__.py
+++ b/test_torment/test_unit/test_fixtures/__init__.py
@@ -406,9 +406,8 @@ class ResolveFunctionsUnitTest(unittest.TestCase):
         def a(self):
             return self.b
 
-        fixtures._resolve_functions({ 'a': a, }, self.f)
-
-        self.assertEqual(id(self.f.a), id(a))
+        with self.assertRaises(AttributeError):
+            fixtures._resolve_functions({ 'a': a, }, self.f)
 
     def test_many_functions(self) -> None:
         '''torment.fixtures._resolve_functions({ 'a': self → self.b, 'b': self → None, }, fixture)'''


### PR DESCRIPTION
Fixtures now have dependency ordering on functions.  This will check
functions for the self paramter and only invoke them if they have it.
It will check for variables being called before-hand and use that to
resolve the order that functions are invoked.
- fixes #44
